### PR TITLE
fix: list refers to the result of a failed type assertion and is a zero value

### DIFF
--- a/dynType/dynType.go
+++ b/dynType/dynType.go
@@ -404,12 +404,12 @@ func (c arrayHandler) Create(v []Value) Value {
 }
 
 func (c arrayHandler) GetElement(i Value, list Value) (Value, error) {
-	if list, ok := list.(vList); ok {
+	if l, ok := list.(vList); ok {
 		i := int(math.Round(i.Float()))
-		if i < 0 || i >= len(list) {
-			return vBool(false), fmt.Errorf("%v index out of bounds %d", list, i)
+		if i < 0 || i >= len(l) {
+			return vBool(false), fmt.Errorf("%v index out of bounds %d", l, i)
 		}
-		return list[i], nil
+		return l[i], nil
 	} else {
 		return vBool(false), fmt.Errorf("%v is not a list", list)
 	}


### PR DESCRIPTION
Reported by the `staticcheck` linter in the [golangci-lint](https://github.com/golangci/golangci-lint)

```text
dynType/dynType.go:414:55: SA9008: list refers to the result of a failed type assertion and is a zero value, not the value that was being type-asserted (staticcheck)
                return vBool(false), fmt.Errorf("%v is not a list", list)
                                                                    ^
```